### PR TITLE
Upgrade SSH.NET version for OS 3.2.3

### DIFF
--- a/Control4.Jailbreak.csproj
+++ b/Control4.Jailbreak.csproj
@@ -59,8 +59,8 @@
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Renci.SshNet, Version=2016.1.0.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106, processorArchitecture=MSIL">
-      <HintPath>packages\SSH.NET.2016.1.0\lib\net40\Renci.SshNet.dll</HintPath>
+    <Reference Include="Renci.SshNet, Version=2020.0.1.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106, processorArchitecture=MSIL">
+      <HintPath>packages\SSH.NET.2020.0.1\lib\net40\Renci.SshNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SSH.NET" version="2016.1.0" targetFramework="net472" />
+  <package id="SSH.NET" version="2020.0.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
SSH.NET in the current version has a bug and throws `error: unexpected filename` on `Upload` method. Upgrade it's version, then OS 3.2.3 works