### PR TITLE
OS 4.2 / Composer 2026.3.18 support

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -2,7 +2,7 @@ namespace Garry.Control4.Jailbreak
 {
     public static class Constants
     {
-        public const int Version = 7;
+        public const int Version = 8;
 
         /// <summary>
         /// The cert for composer needs to be named cacert-*.pem
@@ -43,12 +43,12 @@ namespace Garry.Control4.Jailbreak
         /// <summary>
         /// The OS version this tool was tested against.
         /// </summary>
-        public const string TargetOsVersion = @"4.1.0.743847";
+        public const string TargetOsVersion = @"4.2.0.753182";
 
         /// <summary>
         /// The Composer version this tool was tested against.
         /// </summary>
-        public const string TargetComposerVersion = @"2025.11.26";
+        public const string TargetComposerVersion = @"2026.3.18";
 
         /// <summary>
         /// The file path to the Windows Hosts file, typically used for mapping hostnames to IP addresses.

--- a/UI/Jailbreak.cs
+++ b/UI/Jailbreak.cs
@@ -23,6 +23,7 @@ namespace Garry.Control4.Jailbreak.UI
         private string _cachedJwtToken;
         private bool _loading;
         private string _directorVersion;
+        private string _controllerCommonName;
         private string _lastCheckedIp;
         private readonly Timer _connectionTimer = new Timer { Interval = 10000 };
         private readonly Timer _debounceTimer = new Timer { Interval = 800 };
@@ -202,11 +203,16 @@ namespace Garry.Control4.Jailbreak.UI
                 if (!GenerateComposerCert(log))
                     return;
 
-                // 5. Patch ComposerPro.exe.config (idempotent)
+                // 5. Ensure MQTT JWT signing keypair exists (OS 4.2+)
+                log.WriteHeader("JWT SIGNING KEYPAIR");
+                if (!EnsureJwtSigningKeyPair(log))
+                    return;
+
+                // 6. Patch ComposerPro.exe.config (idempotent)
                 log.WriteHeader("PATCH CONFIG");
                 PatchConfigFile(log);
 
-                // 6-10. Deploy files + settings
+                // 7-11. Deploy files + settings
                 log.WriteHeader("DEPLOY FILES");
 
                 var configFolder = GetComposerConfigFolder();
@@ -215,6 +221,7 @@ namespace Garry.Control4.Jailbreak.UI
                 UpdateUpdateManagerSettings(log, configFolder);
                 ConfigureSplitIoBlock(log, checkBoxBlockSplitIo.Checked);
                 EnsureDealerAccount(log, configFolder);
+                WriteLicenseFile(log, configFolder);
 
                 // 11. Patch Director (SSH)
                 log.WriteHeader("PATCH DIRECTOR");
@@ -231,6 +238,11 @@ namespace Garry.Control4.Jailbreak.UI
                     log.WriteNormal("\nLocal Composer patching succeeded. Run the jailbreak again to retry director patching.\n");
                     return;
                 }
+
+                // Write MQTT JWT cache (OS 4.2+). Harmless on earlier OS — Composer only
+                // consults this cache when the controller advertises SupportsMqtt.
+                log.WriteHeader("JWT CACHE");
+                WriteJwtCache(log, configFolder, _controllerCommonName);
 
                 // 12. Reboot Director if cert chains were modified or a previous reboot is pending
                 if (directorModified)
@@ -512,6 +524,47 @@ namespace Garry.Control4.Jailbreak.UI
         }
 
         // -------------------------------------------------------------------
+        // JWT signing keypair — used to forge MQTT auth tokens on OS 4.2+
+        // -------------------------------------------------------------------
+
+        private bool EnsureJwtSigningKeyPair(LogWindow log)
+        {
+            var keyPath = $"{Constants.CertsFolder}/jailbreak_api.key";
+            var pemPath = $"{Constants.CertsFolder}/jailbreak_api.pem";
+
+            if (File.Exists(keyPath) && File.Exists(pemPath))
+            {
+                log.WriteTrace("JWT signing keypair already exists — skipping.\n");
+                return true;
+            }
+
+            log.WriteNormal("Generating JWT signing private key...\n");
+            var exitCode = RunProcessPrintOutput(log, OpenSslExe,
+                $"genrsa -out \"{keyPath}\" 2048");
+            if (exitCode != 0)
+            {
+                log.WriteError("Key generation failed.\n");
+                return false;
+            }
+
+            log.WriteNormal("Generating JWT signing certificate...\n");
+            exitCode = RunProcessPrintOutput(log, OpenSslExe,
+                "req -new -x509 " +
+                $"-key \"{keyPath}\" " +
+                $"-out \"{pemPath}\" " +
+                "-days 36500 " +
+                "-subj \"/C=US/ST=Utah/L=Draper/O=Control4 Corporation/CN=composerexpress_auth/emailAddress=pki@control4.com\"");
+            if (exitCode != 0)
+            {
+                log.WriteError("Certificate generation failed.\n");
+                return false;
+            }
+
+            log.WriteSuccess("JWT signing keypair generated.\n");
+            return true;
+        }
+
+        // -------------------------------------------------------------------
         // Config file patching (dead proxy + bypasslist)
         // -------------------------------------------------------------------
 
@@ -656,6 +709,26 @@ namespace Garry.Control4.Jailbreak.UI
             }
         }
 
+        private static void WriteLicenseFile(LogWindow log, string configFolder)
+        {
+            // Composer 2026.x aborts at startup if this file is missing.
+            // Contents aren't validated when OnlineServicesAvailable=false — existence is enough.
+            var path = $"{configFolder}/Composer/license.xml";
+            if (File.Exists(path))
+            {
+                log.WriteTrace("license.xml already exists\n");
+                return;
+            }
+            WriteFile(log, path, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<License>
+  <Name>Composer Pro</Name>
+  <Code>ProLicense</Code>
+  <Expiration>2099-01-01</Expiration>
+  <Status>Active</Status>
+  <Purchased>2024-01-01</Purchased>
+</License>");
+        }
+
         private static void EnsureDealerAccount(LogWindow log, string configFolder)
         {
             log.WriteNormal("Checking dealer account... ");
@@ -777,6 +850,8 @@ namespace Garry.Control4.Jailbreak.UI
                 }
                 log.WriteSuccess("connected\n");
 
+                _controllerCommonName = FetchControllerCommonName(scp);
+
                 SyncControllerClock(log, scp);
 
                 if (DownloadRootDeviceSshKeys(log, scp, localKeysFolder, warnings))
@@ -791,6 +866,8 @@ namespace Garry.Control4.Jailbreak.UI
                 anyModified |= PatchRemoteCertChain(log, scp, "/etc/openvpn/clientca-prod.pem", localCert);
                 anyModified |= PatchRemoteCertChain(log, scp, "/opt/control4/etc/ssl/certs/clientca-prod.pem", localCert);
                 anyModified |= PatchRemoteCertChain(log, scp, "/etc/mosquitto/certs/ca-chain.pem", localCert);
+
+                PatchControllerApiPem(log, scp);
 
                 if (anyModified)
                 {
@@ -819,6 +896,112 @@ namespace Garry.Control4.Jailbreak.UI
             }
 
             return anyModified;
+        }
+
+        /// <summary>
+        /// Appends jailbreak_api.pem to /opt/control4/etc/ssl/certs/api.pem so the mosquitto-jwt-auth
+        /// plugin (OS 4.2+) accepts JWTs signed with our keypair. Unlike the CA chain patches,
+        /// this is a per-cert append (the plugin's pem_parser iterates every BEGIN CERTIFICATE block)
+        /// and we must kill the daemon to pick up the new key — it only reads the PEM at startup.
+        /// No reboot required — sysmand respawns the daemon within ~10 seconds.
+        ///
+        /// Dedupe strategy: strip any self-signed cert with CN=composerexpress_auth before appending,
+        /// which cleans up orphaned jailbreak certs from previous runs where the local keypair was
+        /// regenerated. The production cert shares the CN but is issued by "Control4 Primary Root CA"
+        /// (Subject != Issuer), so it survives the filter.
+        /// </summary>
+        private static void PatchControllerApiPem(LogWindow log, ScpClient scp)
+        {
+            const string remoteFile = "/opt/control4/etc/ssl/certs/api.pem";
+            var localPemPath = $"{Constants.CertsFolder}/jailbreak_api.pem";
+
+            log.WriteNormal($"Patching {remoteFile}:\n");
+
+            if (!File.Exists(localPemPath))
+            {
+                log.WriteWarning($"  {localPemPath} missing — skipping\n");
+                return;
+            }
+
+            string remotePem;
+            try
+            {
+                log.WriteNormal($"  Downloading {remoteFile}... ");
+                remotePem = DownloadFile(scp, remoteFile);
+                log.WriteSuccess("done\n");
+            }
+            catch (ScpException)
+            {
+                log.WriteTrace("  file doesn't exist (pre-OS 4.2) — skipping\n");
+                return;
+            }
+
+            var ourPem = File.ReadAllText(localPemPath).Trim();
+
+            var kept = ExtractPemBlocks(remotePem)
+                .Where(pem => !IsOrphanJailbreakCert(pem))
+                .ToList();
+
+            var rebuilt = string.Join("\n", kept.Concat(new[] { ourPem })).Trim() + "\n";
+            var original = string.Join("\n", ExtractPemBlocks(remotePem)).Trim() + "\n";
+
+            if (rebuilt == original)
+            {
+                log.WriteTrace("  (already patched)\n");
+                return;
+            }
+
+            var backupFilename = $"api.pem.{DateTime.Now:yyyy-dd-M--HH-mm-ss}.backup";
+            log.WriteNormal($"  Saving remote backup to /opt/control4/etc/ssl/certs/{backupFilename}... ");
+            UploadFile(scp, $"/opt/control4/etc/ssl/certs/{backupFilename}", remotePem);
+            log.WriteSuccess("done\n");
+
+            log.WriteNormal($"  Saving local backup to {Constants.CertsFolder}/{backupFilename}... ");
+            File.WriteAllText($"{Constants.CertsFolder}/{backupFilename}", remotePem);
+            log.WriteSuccess("done\n");
+
+            log.WriteNormal($"  Updating {remoteFile}... ");
+            UploadFile(scp, remoteFile, rebuilt);
+            log.WriteSuccess("done\n");
+
+            log.WriteNormal("  Restarting mosquitto-jwt-auth... ");
+            using (var ssh = new SshClient(scp.ConnectionInfo))
+            {
+                ssh.Connect();
+                // Plugin loads the PEM only at startup; sysmand respawns the process within ~10s.
+                ssh.RunCommand("pidof mosquitto-jwt-auth | xargs -r kill -9");
+                ssh.Disconnect();
+            }
+            log.WriteSuccess("done\n");
+        }
+
+        private static IEnumerable<string> ExtractPemBlocks(string pemText)
+        {
+            const string beginMarker = "-----BEGIN CERTIFICATE-----";
+            const string endMarker = "-----END CERTIFICATE-----";
+            var startIdx = 0;
+            while ((startIdx = pemText.IndexOf(beginMarker, startIdx, StringComparison.Ordinal)) >= 0)
+            {
+                var endIdx = pemText.IndexOf(endMarker, startIdx, StringComparison.Ordinal);
+                if (endIdx < 0) yield break;
+                yield return pemText.Substring(startIdx, endIdx - startIdx + endMarker.Length).Trim();
+                startIdx = endIdx + endMarker.Length;
+            }
+        }
+
+        private static bool IsOrphanJailbreakCert(string pem)
+        {
+            try
+            {
+                var cert = new X509Certificate2(Encoding.UTF8.GetBytes(pem));
+                var isSelfSigned = cert.Subject == cert.Issuer;
+                var isOurCn = cert.Subject.IndexOf("CN=composerexpress_auth", StringComparison.Ordinal) >= 0;
+                return isSelfSigned && isOurCn;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -1086,6 +1269,185 @@ namespace Garry.Control4.Jailbreak.UI
             {
                 // Non-fatal — don't block the jailbreak if clock sync fails
             }
+        }
+
+        /// <summary>
+        /// Fetches the controller's common name (control4_{model}_{mac}) by reading the subject CN
+        /// from its own cert. This is what Composer uses to look up the JWT cache and what the
+        /// mosquitto-jwt-auth plugin expects in the signed JWT's CommonName claim.
+        /// NOTE: the Linux hostname uses a different format (hyphen-separated, no model prefix)
+        /// and is NOT what we want.
+        /// </summary>
+        private static string FetchControllerCommonName(ScpClient scp)
+        {
+            // agent.pem and client.pem both carry the controller's CN; agent.pem is the canonical one.
+            foreach (var remote in new[]
+                     {
+                         "/opt/control4/etc/ssl/certs/agent.pem",
+                         "/opt/control4/etc/ssl/certs/client.pem"
+                     })
+            {
+                try
+                {
+                    var pem = DownloadFile(scp, remote);
+                    var block = ExtractPemBlocks(pem).FirstOrDefault();
+                    if (block == null) continue;
+                    var cert = new X509Certificate2(Encoding.UTF8.GetBytes(block));
+                    var cn = cert.GetNameInfo(X509NameType.SimpleName, false);
+                    if (!string.IsNullOrEmpty(cn)) return cn;
+                }
+                catch
+                {
+                    // try next
+                }
+            }
+            return null;
+        }
+
+        // -------------------------------------------------------------------
+        // JWT cache (OS 4.2+ — bypasses the ControllersForm cloud-status gate)
+        // -------------------------------------------------------------------
+
+        private bool WriteJwtCache(LogWindow log, string configFolder, string commonName)
+        {
+            if (string.IsNullOrEmpty(commonName))
+            {
+                log.WriteWarning("Controller common name unknown — skipping JWT cache write.\n");
+                return false;
+            }
+
+            var cacheDir = $"{configFolder}/JwtCache";
+            Directory.CreateDirectory(cacheDir);
+            var cachePath = $"{cacheDir}/{commonName}.jwtcache";
+
+            // Idempotency: skip if a non-stale entry is already present.
+            if (File.Exists(cachePath) && IsJwtCacheFresh(cachePath))
+            {
+                log.WriteTrace($"JWT cache for {commonName} already fresh — skipping.\n");
+                return true;
+            }
+
+            var dealerUsername = ReadDealerUsername(configFolder) ?? "no";
+            log.WriteNormal($"Signing MQTT JWT for {commonName}... ");
+
+            var jwt = SignMqttJwt(log, commonName);
+            if (jwt == null)
+            {
+                log.WriteError("failed\n");
+                return false;
+            }
+            log.WriteSuccess("done\n");
+
+            var json =
+                "{\"entries\":{\"" + JsonEscape(dealerUsername) + "\":{" +
+                "\"token\":\"" + jwt + "\"," +
+                "\"expiresUtc\":\"2099-01-01T00:00:00Z\"}}}";
+
+            WriteFile(log, cachePath, json);
+            return true;
+        }
+
+        private static bool IsJwtCacheFresh(string path)
+        {
+            try
+            {
+                var text = File.ReadAllText(path);
+                var parsed = new System.Web.Script.Serialization.JavaScriptSerializer()
+                    .DeserializeObject(text) as Dictionary<string, object>;
+                if (parsed == null || !(parsed["entries"] is Dictionary<string, object> entries))
+                    return false;
+                foreach (var entry in entries.Values.OfType<Dictionary<string, object>>())
+                {
+                    if (!entry.TryGetValue("expiresUtc", out var expiresUtc)) continue;
+                    if (!DateTime.TryParse(expiresUtc?.ToString(), null,
+                            System.Globalization.DateTimeStyles.AssumeUniversal |
+                            System.Globalization.DateTimeStyles.AdjustToUniversal, out var expiry))
+                        continue;
+                    if (expiry > DateTime.UtcNow.AddDays(1))
+                        return true;
+                }
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string ReadDealerUsername(string configFolder)
+        {
+            var path = $"{configFolder}/dealeraccount.xml";
+            if (!File.Exists(path)) return null;
+            try
+            {
+                return XDocument.Load(path).Root?.Element("Username")?.Value;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Builds and signs an RS256 JWT matching the shape the controller's mosquitto-jwt-auth
+        /// plugin (OS 4.2+) expects. Uses jailbreak_api.key via OpenSSL for the signature.
+        /// </summary>
+        private string SignMqttJwt(LogWindow log, string commonName)
+        {
+            var keyPath = $"{Constants.CertsFolder}/jailbreak_api.key";
+            if (!File.Exists(keyPath))
+            {
+                log.WriteError($"{keyPath} missing.\n");
+                return null;
+            }
+
+            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var exp = now + 30 * 24 * 60 * 60; // 30 days
+
+            var header = "{\"alg\":\"RS256\",\"typ\":\"JWT\"}";
+            var payload =
+                "{\"CommonName\":\"" + JsonEscape(commonName) + "\"," +
+                "\"Services\":\"director,sysman\"," +
+                "\"UserName\":\"CN=" + Constants.CertificateCn + ",L=Draper,ST=Utah,C=US\"," +
+                "\"Permissions\":\"/sysman,/director\"," +
+                "\"iat\":" + now + "," +
+                "\"exp\":" + exp + "}";
+
+            var headerB64 = Base64Url(Encoding.UTF8.GetBytes(header));
+            var payloadB64 = Base64Url(Encoding.UTF8.GetBytes(payload));
+            var signingInput = headerB64 + "." + payloadB64;
+
+            var tempInput = Path.GetTempFileName();
+            var tempSig = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(tempInput, Encoding.UTF8.GetBytes(signingInput));
+
+                var exitCode = RunProcessPrintOutput(log, OpenSslExe,
+                    $"dgst -sha256 -sign \"{keyPath}\" -binary -out \"{tempSig}\" \"{tempInput}\"");
+                if (exitCode != 0) return null;
+
+                var sigBytes = File.ReadAllBytes(tempSig);
+                return signingInput + "." + Base64Url(sigBytes);
+            }
+            finally
+            {
+                try { File.Delete(tempInput); } catch { /* ignore */ }
+                try { File.Delete(tempSig); } catch { /* ignore */ }
+            }
+        }
+
+        private static string Base64Url(byte[] data)
+        {
+            return Convert.ToBase64String(data)
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
+        }
+
+        private static string JsonEscape(string s)
+        {
+            return s.Replace("\\", "\\\\").Replace("\"", "\\\"");
         }
 
         // -------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Adds support for Control4 OS 4.2 and Composer Pro 2026.x. **Backwards compatible** — tested with OS 3.3 through 4.2.

Confirmed working 2026-04-16 on an EA-1 and a Core-1.

### What changed in Control4 between 4.1 and 4.2

| # | Change | Effect |
|---|---|---|
| 1 | Composer 2026 added a mandatory `license.xml` file check | Composer aborts at startup if absent |
| 2 | `ControllersForm.SetControllerInfo` added a new cloud-status gate gated on a cached JWT | Controllers show `Cloud status update failed: internet unavailable`; Connect is disabled |
| 3 | OS 4.2 broker removed the password-auth fallback that `dealeraccount.xml` was riding through | Every MQTT route now requires a JWT verified against `/opt/control4/etc/ssl/certs/api.pem` |
| 4 | Composer 2026 added a new `SplitIOTimeout` (20 s) during startup | Stalls startup by 20 s when `split.io` is blocked. Not a hard fail |

### Fix

Four new idempotent steps on top of the existing 4.1 flow:

- **JWT signing keypair** — Generates `Certs/jailbreak_api.{key,pem}` once and reuses it across runs. Key is preserved across jailbreak runs because it was appended to the controller's `api.pem`; regenerating would invalidate every previously-signed JWT.
- **`license.xml` placeholder** — Writes a minimal `%AppData%\Control4\Composer\license.xml`. Content isn't validated when `OnlineServicesAvailable=false` — existence alone satisfies Composer.
- **Controller-side `api.pem` append** — Appends our signing cert to `/opt/control4/etc/ssl/certs/api.pem` and kills `mosquitto-jwt-auth` so sysmand respawns the daemon with the new key loaded. **Append, never replace** — preserves the production cert so real cloud-issued JWTs still verify for anyone with real dealer credentials. Orphan self-signed `composerexpress_auth` certs from prior runs (if the local keypair was regenerated) are stripped before the new one is appended; the production cert survives the filter because its issuer is `Control4 Primary Root CA` (`Subject != Issuer`).
- **Signed JWT cache** — Writes a PascalCase-claim RS256 JWT to `%AppData%\Control4\JwtCache\{commonName}.jwtcache` (filename and `CommonName` claim are both read from the controller's `agent.pem` subject, **not** the Linux hostname). This short-circuits `ControllersForm.SetControllerInfo`'s cloud-status gate. The JWT's `iat`/`exp` is 30 days; the outer `expiresUtc` wrapper is set to 2099 so Composer doesn't refetch.

### Fail-safe on pre-4.2

- `/opt/control4/etc/ssl/certs/api.pem` doesn't exist pre-4.2 → `ScpException` caught → cleanly skips
- Older Composer versions ignore `license.xml` and the JWT cache — dead files, no side effects
- OS 3.3 / 4.0 / 4.1 flows unaffected; no version gate needed

### Jailbreak Steps

1. Download and install **Composer Pro** (2026.x recommended for OS 4.2; 2025.x still works on OS 4.1 and earlier).
2. Run the jailbreak tool, enter your controller's IP address, and click **Jailbreak**.
   Ensure **"Block cloud feature service"** is checked (recommended).
3. If the status bar shows "Management pack not installed", click **Install Pack** to download and install it.
4. Open Composer and connect to your project.

### Upgrading Your Controller

The upgrade flow hasn't changed since v7:

1. If upgrading past OS 3.4.3, ensure you are subscribed to the **Connect** plan.
2. In Composer, go to `Tools` > `Update Manager...`. For the "Update URL":
   - **OS 3.x:** `https://services.control4.com/Updates2x/v2_0/Updates.asmx` (default)
   - **OS 4.0+:** `https://services.control4.com/Updates2x-experience/v2_0/Updates.asmx`
3. After upgrading, download and install the new management pack for the upgraded OS version once the controller is back online.
4. Run the jailbreak tool again to patch the new Director version and (on OS 4.2+) seed the MQTT JWT cache.

### Testing

Manual verification on EA-1 and Core-1 running OS `4.2.0.753182-res`, Composer `2026.3.18.506-res`:

- [x] Composer reaches controller list; each controller shows Ready to connect
- [x] Clicking Connect passes MQTT auth (was `CONNACK rc=5 / NotAuthorized`)
- [x] Director:5021 session establishes; MitM plaintext capture works as on 4.1
- [x] 4.1 Composer (`2025.11.26.463-res`) still connects to 4.1 controllers through the same jailbreak setup (no regression)
- [x] After controller reboot, append-based `api.pem` persists and `mosquitto-jwt-auth` loads it on cold start

<details>
<summary><b>Reviewer notes — gate logic, things to watch out for, RE notes</b></summary>

#### The gate logic

From `Control4.Designer.Controls.dll :: ControllersForm.SetControllerInfo`:
```csharp
if (controller.Version.Features.SupportsMqtt
    && !C4System.Instance.OnlineServicesAvailable
    && string.IsNullOrWhiteSpace(
         new JwtCacher().Get(controller.CommonName,
                             C4System.Instance.DealerAccountInfo.Username)?.Token))
{
    controller.ControllerStatus = ControllerStatus.CloudServicesRequiredButNotAvailable;
}
else if (_handleOsPackOnConnect) {
    controller.ControllerStatus = ControllerStatus.Ready;
}
```
All three conditions AND together — feeding any non-empty `Token` back from `JwtCacher.Get` short-circuits the whole thing. Composer then uses that same cached JWT as the MQTT password against `mosquitto-jwt-auth` on port 8884, which verifies it against `api.pem`.

#### JWT claim shape

```
{
  "CommonName":  "<controller common name, e.g. control4_<model>_<mac>>",
  "Services":    "director,sysman",
  "UserName":    "CN=Composer_tech@control4.com_dev,L=Draper,ST=Utah,C=US",
  "Permissions": "/sysman,/director",
  "iat": now,
  "exp": now + 30*86400
}
```
`Permissions` values must start with `/` (checked via prefix match by `routeHelper.IsPermitted`). `UserName` string should match the client cert subject DN for cleanliness; `validate_sub_match_username=false` in `mosquitto-jwt-auth.conf` means it's not strictly required to match.

#### Things to watch out for

1. **Do not use the `/api/v1/localjwt` endpoint for the cache JWT.** That endpoint signs with `config.get('httpsCertContent')` — a key unrelated to `api.pem`. It verifies against the controller's own internal checks but `mosquitto-jwt-auth` rejects it. Forge the JWT ourselves with the key that matches `api.pem`.
2. **Claim case matters.** `permissions` (lowercase) is what `routeHelper.IsPermitted` reads; `Permissions` (PascalCase) is what the plugin requires for the claim name in the JWT payload itself. Both happen to be true simultaneously because the Rust plugin uses PascalCase struct fields (`mosquitto_jwt_auth::Claims`) and the JS-side `routeHelper` reads lowercase keys from what's already been deserialized into `jwtDecoded`. Sign with PascalCase.
3. **mosquitto port 8884 also requires mTLS** on top of JWT. The existing jailbreak's `composer.p12` CA append to `/etc/mosquitto/certs/ca-chain.pem` handles this — no change needed.
4. **Controller's own internal clients** (bridge, director, HomeScreenAgent) connect on port 8883 with cert auth, not 8884 with JWT. Appending to `api.pem` does not affect them.
5. **`mosquitto-jwt-auth` is a separate process** from `mosquitto` and loads the PEM only at startup — SIGHUP is not enough; the process must be killed so sysmand respawns it.

#### Reverse-engineering notes

- `Control4.Client.dll` method bodies are AgileDotNet-encrypted; string literals in the `#US` heap are XOR'd with a per-build 114-byte key. The key lives in `<Control4ClientRT>` static ctor. Decompile with `ilspycmd`, extract strings with a `#US` parser + XOR script.
- `Control4.Designer.Controls.dll` is plain .NET — decompiles fully. The `ControllersForm` logic and JWT cache usage was all findable here.
- Controller broker JS (`mnt/internal/node/broker/*.js`) uses the classic `obfuscator.io` rotated-array pattern. Array rotation is `0x10c` for broker.js, `0x1cf` for wsConvenience.js.
- `mosquitto-jwt-auth` plugin (`/opt/control4/lib/libmosquitto_jwt_auth.so`) is Rust, strippable but symbols are unstripped, so `objdump -t` gives you function offsets. Key functions: `mosquitto_auth_unpwd_check` (plugin entry, offset `0xb0cc0`), `PluginInstance::authenticate_user` (`0x97b20`), `pem_parser::keys_from_pem_file`.
- `gdbserver.i686` dropped to `/tmp/gdbserver` on the controller lets you attach from `gdb-multiarch` on a Linux host and inspect the JWT bytes passed to `mosquitto_auth_unpwd_check` directly — this is how the PascalCase claim shape was confirmed.

</details>
